### PR TITLE
Part 2: Refactor & Document the library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This library provides for both Stable and Shared collections and conversions.  T
 - [ ] Tests  
 - [ ] Examples
 
-
 ## Structure
 The provided functionality is divided into separate libraries to silo some of the functionality.
 
@@ -16,7 +15,7 @@ Holds most types and few conversion functions to stabilize/destabilize candy val
 
 `CandyShared` and `Candy` allow you to specify your variables in a variant class that makes keeping arrays and buffers of different types managable.  i.e. stable var `myCollection : [CandySharedStable] = [#Int(0), #Text("second value"), #Float(3.14)]`.
 
-Stabalize and Destablaize functions are provided for both CandyShared <> Candy, Properties <> Property, [CandyShared] <> [Candy].
+Stabalize and Destablaize functions are provided for both `CandyShared <> Candy`, `Properties <> Property`, `[CandyShared] <> [Candy]`.
 
 #### conversion.mo
 Holds most of the conversion functions.
@@ -80,7 +79,7 @@ Useful for keeping workable data in chunks that can be moved around canisters.
 
 Workspace collections help manage data and can help chunk data into chunks sized to send across another canister or return to a calling client. These calls are limited to ~2MB and this library can help you keep chunks of data together for easy monitoring. Workspaces can be deconstructed into `AddressedChunckArrays` that can be shipped elsewhere and reassembled using the address of the chunks on the other side of an async call. For more information and helper libraries see the pipelinify project. 
 
-* `workspaceToAddressedChunkArray` - convert a workspace to an AddressedChunkArray
+* `workspaceToAddressedChunkArray` - convert a workspace to an `AddressedChunkArray`
 * `workspaceDeepClone` - clone a workspace
 * `fromAddressedChunks` - reconsitute a workspace from and `AddressedChunkArray`
 * `getDataZoneSize` - inspects the size of the datazone. 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # candy_library
 Library for Converting Types and Creating Workable Motoko Collections
 
-This library provides for both Stable and Shared collections and conversions.  These methods help with keeping data in unstable workable runtime memory while providing methods to convert those objects to stable collections that can be put into upgrade variables for persistence across upgrades or for shipping the objects to other canisters and returning them as async functions. 
+This library provides for both Stable and Shared collections and conversions.  These methods help with keeping data in unstable workable runtime memory while providing methods to convert those objects to stable collections that can be put into upgrade variables for persistence across upgrades or for shipping the objects to other canisters and returning them as async functions.
 
-I have refactored the files into separate libraries to silo some of the functionality.
+#### Todo
+- [ ] Tests  
+- [ ] Examples
 
-type.mo - holds most types and few conversion functions to stabilize/destabilize candy values, properties, and workspace types.
 
-conversion.mo - holds most of the conversion functions
+## Structure
+The provided functionality is divided into separate libraries to silo some of the functionality.
 
-clone.mo - has some clone functions for deep cloning classes
+#### type.mo
+Holds most types and few conversion functions to stabilize/destabilize candy values, properties, and workspace types.
 
-properties.mo - property and class functions for updating and manipulating classes
+`CandyShared` and `Candy` allow you to specify your variables in a variant class that makes keeping arrays and buffers of different types managable.  i.e. stable var `myCollection : [CandySharedStable] = [#Int(0), #Text("second value"), #Float(3.14)]`.
 
-workspace.mo - useful for keeping workable data in chunks that can be moved around canisters.
+Stabalize and Destablaize functions are provided for both CandyShared <> Candy, Properties <> Property, [CandyShared] <> [Candy].
 
-CandyShared and Candy allow you to specify your variables in a variant class that makes keeping arrays and buffers of different types managable.  ie stable var myCollection : [CandySharedStable] = [#Int(0), #Text("second value"), #Float(3.14)]
+#### conversion.mo
+Holds most of the conversion functions.
 
-The property objects (adapted from https://github.com/DepartureLabsIC/non-fungible-token/blob/main/src/property.mo with copyright DepartureLabs and under MIT License, included here for compilability reasons.) allow for Key/Value collections that can be easily created, queried, and updated.  We include conversions between stable and unstable properties.
-
-We provide the following conversion methods.  Most will assert(false if you try to output an impossible conversion.):
+We provide the following conversion methods. Note that most of these will `assert(false)` if you try to output an impossible conversion.
 
 * CandyShared -> Nat
 * CandyShared -> Nat8
@@ -59,43 +61,48 @@ We provide the following conversion methods.  Most will assert(false if you try 
 * Candy -> Byte Buffer Buffer.Buffer<Nat8>
 * Candy -> Float Buffer Buffer.Buffer<Float>
 
-Clone Functions exist to clone unstable values into new variables, 
-
-#Option variant types can be unwrapped with unwrapOptionCandy and unwrapOptionCandyShared and will return #Empty if the option was null.
-
-Stabalize and Destablaize functions are provided for both CandyShared <> Candy, Properties <> Property, [CandyShared] <> [Candy].
+`#Option` variant types can be unwrapped with `unwrapOptionCandy` and `unwrapOptionCandyShared` and will return `#Empty` if the option was null.
 
 A toBuffer function will convert an Array to a Buffer of the same type.  The is a n on n function and will iterate through each item in the array.
 
-We provide a number of functions that convert base types to byte arrays and back that can easily be converted to blobs using the Blob base library.  Supports: Nat, Nat[64,32,16], Text, Principal, Bool, Int
+We provide a number of functions that convert base types to byte arrays and back that can easily be converted to blobs using the Blob base library. Supports: Nat, Nat[64,32,16], Text, Principal, Bool, Int
 
-Workspace collections help manage data and can help chunk data into chunks sized to send across another canister or return to a calling client.  These calls are limited to ~2MB and this library can help you keep chunks of data together for easy monitoring. Workspaces can be deconstructed into AddressedChunckArrays that can be shipped elsewhere and reassembled using the address of the chunks on the other side of an async call.For more information and helper libraries see the pipelinify project. 
+#### clone.mo 
+Has some clone functions for deep cloning classes. The clone functions exist to clone unstable values into new variables.
 
-* workspaceToAddressedChunkArray - convert a workspace to an AddressedChunkArray
-* workspaceDeepClone - clone a workspace
-* fromAddressedChunks - reconsitute a workspace from and AddressedChunkArray
-* getDataZoneSize - inspects the size of the datazone. 
-* getWorkspaceChunkSize - Gets the number of chunks a workspace will be split into given a max chunk size
-* getWorkspaceChunk - gets the nth chunk given a max chunk size(recomended 2MB)
-* getAddressedChunkArraySize - returns the size of an AddressedChunkArray
-* getDataChunkFromAddressedChunkArray - returns the addressed chunk out of an AddresedChunkArray
-* byteBufferDataZoneToBuffer - specifically converts a DataZone containing a ByteBuffer into a ByteBuffer
-* byteBufferChunksToValueSharedBufferDataZone - converts a ByteBuffer into a DataZone
-* initDataZone - initializes a datazone
-* flattenAddressedChunkArray - Converts an addressed chunk array into a pure byte array. Breaks after 256 Zones or 256 Chunks.
+#### properties.mo
+Property and class functions for updating and manipulating classes.
 
-Todo: Tests, examples
+The property objects (adapted from https://github.com/DepartureLabsIC/non-fungible-token/blob/main/src/property.mo with copyright DepartureLabs and under MIT License, included here for compilability reasons.) allow for Key/Value collections that can be easily created, queried, and updated.  We include conversions between stable and unstable properties.
 
-Note: This project was a part of the [ARAMAKME expirament](https://hwqwz-ryaaa-aaaai-aasoa-cai.raw.ic0.app/) and an example of how to integrate an ARAMAKME license into a library can be found in the /Example_Aramakme_License folder.  The ARAMAKME license has since been removed from this library and it is licensed under the MIT License.  Until they are all distributed, the ARAMAKME NFTs are still for sale as a nastalgoic piece of memorobilia, and all profits will be locked into an 8 year neuron benifiting [ICDevs.org](https://icdevs.org) who are sheparding this library as it moves forward and improves.
+#### workspace.mo
+Useful for keeping workable data in chunks that can be moved around canisters.
 
+Workspace collections help manage data and can help chunk data into chunks sized to send across another canister or return to a calling client. These calls are limited to ~2MB and this library can help you keep chunks of data together for easy monitoring. Workspaces can be deconstructed into `AddressedChunckArrays` that can be shipped elsewhere and reassembled using the address of the chunks on the other side of an async call. For more information and helper libraries see the pipelinify project. 
+
+* `workspaceToAddressedChunkArray` - convert a workspace to an AddressedChunkArray
+* `workspaceDeepClone` - clone a workspace
+* `fromAddressedChunks` - reconsitute a workspace from and `AddressedChunkArray`
+* `getDataZoneSize` - inspects the size of the datazone. 
+* `getWorkspaceChunkSize` - Gets the number of chunks a workspace will be split into given a max chunk size
+* `getWorkspaceChunk` - gets the nth chunk given a max chunk size(recomended 2MB)
+* `getAddressedChunkArraySize` - returns the size of an `AddressedChunkArray`
+* `getDataChunkFromAddressedChunkArray` - returns the addressed chunk out of an `AddresedChunkArray`
+* `byteBufferDataZoneToBuffer` - specifically converts a `DataZone` containing a `ByteBuffer` into a `ByteBuffer`
+* `byteBufferChunksToValueSharedBufferDataZone` - converts a `ByteBuffer` into a `DataZone`
+* `initDataZone` - initializes a `Datazone`
+* `flattenAddressedChunkArray` - Converts an addressed chunk array into a pure byte array. Breaks after 256 Zones or 256 Chunks.
 
 ## Testing
+From the root directory of the project, execute the following command:
 
-    printf "yes" | bash test_runner.sh
+```bash
+printf "yes" | bash test_runner.sh
+```
 
-## Release
+## Releases
 
-v0.2.0
+#### v0.2.0
 
 * Major breaking changes
 * Value is now CandyShared
@@ -103,8 +110,10 @@ v0.2.0
 * Added a stable hash
 * Todo: fund a better eq function than to_candid, from_candid
 
-v0.1.12
+#### v0.1.12
 
 * Refactor - Cleaned up code
 * JSON - added a library to dump values to JSON
 
+## Note 
+This project was a part of the [ARAMAKME expirament](https://hwqwz-ryaaa-aaaai-aasoa-cai.raw.ic0.app/) and an example of how to integrate an ARAMAKME license into a library can be found in the /Example_Aramakme_License folder.  The ARAMAKME license has since been removed from this library and it is licensed under the MIT License.  Until they are all distributed, the ARAMAKME NFTs are still for sale as a nastalgoic piece of memorobilia, and all profits will be locked into an 8 year neuron benifiting [ICDevs.org](https://icdevs.org) who are sheparding this library as it moves forward and improves.

--- a/src/conversion.mo
+++ b/src/conversion.mo
@@ -50,7 +50,7 @@ module {
   type DataZone = Types.DataZone;
   type PropertyShared = Types.PropertyShared;
   type Property = Types.Property;
-
+  type StableBuffer<T> = StableBuffer.StableBuffer<T>;
 
   //todo: generic accesors
 
@@ -497,7 +497,6 @@ module {
   /// ```
   /// Note: Throws if the underlying value is not a `#Principal`.
   public func candyToPrincipal(val : Candy) : Principal {
-   
     switch(val){
       case(#Principal(val)){val};
       case(_){assert(false);/*unreachable*/Principal.fromText("");};
@@ -630,6 +629,44 @@ module {
       case(#Bytes(val)){Buffer.fromArray(StableBuffer.toArray(val))};
       case(_){
           toBuffer<Nat8>(candyToBytes(val));//may throw for uncovertable types
+      };
+    };
+  };
+
+  /// Convert a `Candy` to `Buffer<Float>`
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let value: Candy = #Nat(102);
+  /// let value_as_floats_buffer = Conversion.candyToFloatsBuffer(value);
+  /// ```
+  /// Note: Throws if the underlying value isn't convertible.
+  public func candyToFloatsBuffer(val : Candy) : Buffer.Buffer<Float>{
+    switch (val){
+      case(#Floats(val)){
+        stableBufferToBuffer(val);
+      };
+      case(_){
+        toBuffer([candyToFloat(val)]); //may throw for unconvertable types
+      };
+    };
+  };
+
+  /// Convert a `Candy` to `Buffer<Nat>`
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let value: Candy = #Nat(102);
+  /// let value_as_nats_buffer = Conversion.candyToNatsBuffer(value);
+  /// ```
+  /// Note: Throws if the underlying value isn't convertible.
+  public func candyToNatsBuffer(val : Candy) : Buffer.Buffer<Nat>{
+    switch (val){
+      case(#Nats(val)){
+        stableBufferToBuffer(val);
+      };
+      case(_){
+          toBuffer([candyToNat(val)]); //may throw for unconvertable types
       };
     };
   };
@@ -1288,9 +1325,23 @@ module {
   ///  let buf = Conversion.toBuffer<Nat>(array);
   /// ```
   public func toBuffer<T>(x :[T]) : Buffer.Buffer<T>{
-    
     let thisBuffer = Buffer.Buffer<T>(x.size());
     for(thisItem in x.vals()){
+      thisBuffer.add(thisItem);
+    };
+    return thisBuffer;
+  };
+
+  /// Create a `Buffer<T>` from `StableBuffer<T>` where T can be of any type.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let stable_buff = StableBuffer.fromArray([1, 2, 3]);
+  /// let buff = Conversion.stableBufferToBuffer(stable_buff);
+  /// ```
+  public func stableBufferToBuffer<T>(x : StableBuffer<T>) : Buffer.Buffer<T>{
+    let thisBuffer = Buffer.Buffer<T>(StableBuffer.size(x));
+    for(thisItem in StableBuffer.vals(x)){
       thisBuffer.add(thisItem);
     };
     return thisBuffer;

--- a/src/conversion.mo
+++ b/src/conversion.mo
@@ -580,6 +580,60 @@ module {
     };
   };
 
+  /// Convert a `Candy` to Bytes(`[Nat8]`)
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let value: Candy = #Principal(Principal.fromText("abc"));
+  /// let value_as_bytes = Conversion.candyToBytes(value);
+  /// ```
+  public func candyToBytes(val : Candy) : [Nat8]{
+    switch(val){
+      case(#Int(val)){intToBytes(val)};
+      case(#Int8(val)){candyToBytes(#Int(candyToInt(#Int8(val))))};
+      case(#Int16(val)){candyToBytes(#Int(candyToInt(#Int16(val))))};
+      case(#Int32(val)){candyToBytes(#Int(candyToInt(#Int32(val))))};
+      case(#Int64(val)){candyToBytes(#Int(candyToInt(#Int64(val))))};
+      case(#Nat(val)){natToBytes(val)};
+      case(#Nat8(val)){ [val]};
+      case(#Nat16(val)){nat16ToBytes(val)};
+      case(#Nat32(val)){nat32ToBytes(val)};
+      case(#Nat64(val)){nat64ToBytes(val)};
+      case(#Float(val)){Prelude.nyi()};
+      case(#Text(val)){textToBytes(val)};
+      case(#Bool(val)){boolToBytes(val)};
+      case(#Blob(val)){ Blob.toArray(val)};
+      case(#Class(val)){Prelude.nyi()};
+      case(#Principal(val)){principalToBytes(val)};
+      case(#Option(val)){Prelude.nyi()};
+      case(#Array(val)){Prelude.nyi()};
+      case(#Bytes(val)){StableBuffer.toArray(val)};
+      case(#Floats(val)){Prelude.nyi()};
+      case(#Nats(val)){Prelude.nyi()};
+      case(#Ints(val)){Prelude.nyi()};
+      case(#Map(val)){Prelude.nyi()};
+      case(#Set(val)){Prelude.nyi()};
+    }
+  };
+
+  /// Convert a `Candy` to `Buffer<Nat8>`
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// let value: Candy = #Principal(Principal.fromText("abc"));
+  /// let value_as_buffer = Conversion.candyToBytesBuffer(value);
+  /// ```
+  ///
+  /// Note: Throws if the underlying value isn't convertible.
+  public func candyToBytesBuffer(val : Candy) : Buffer.Buffer<Nat8>{
+    switch (val){
+      case(#Bytes(val)){Buffer.fromArray(StableBuffer.toArray(val))};
+      case(_){
+          toBuffer<Nat8>(candyToBytes(val));//may throw for uncovertable types
+      };
+    };
+  };
+
   /// Convert a `CandyShared` to `Nat`.
   ///
   /// Example:
@@ -779,7 +833,6 @@ module {
   /// ```
   /// Note: Throws if the underlying value overflows.
   public func candySharedToInt(val : CandyShared) : Int {
-
     switch(val){
       case(#Int(val)){val};
       case(#Int8(val)){ Int8.toInt(val)};
@@ -805,7 +858,6 @@ module {
   /// ```
   /// Note: Throws if the underlying value overflows.
   public func candySharedToInt8(val : CandyShared) : Int8 {
-
     switch(val){
       case(#Int8(val)){ val};
       case(#Int(val)){ Int8.fromInt(val)};//will throw on overflow
@@ -831,7 +883,6 @@ module {
   /// ```
   /// Note: Throws if the underlying value overflows.
   public func candySharedToInt16(val : CandyShared) : Int16 {
-
     switch(val){
       case(#Int16(val)){ val};
       case(#Int8(val)){ Int16.fromInt(Int8.toInt(val))};
@@ -1061,7 +1112,6 @@ module {
   /// ```
   public func candySharedToBlob(val : CandyShared) : Blob {
     switch(val){
-
       case(#Blob(val)){ val};
       case(#Bytes(val)){
           Blob.fromArray(val);
@@ -1108,48 +1158,11 @@ module {
   /// ```
   /// Note: Throws if the underlying value is not an `#Array`.
   public func candySharedToValueArray(val : CandyShared) : [CandyShared] {
-
     switch(val){
       case(#Array(val)){val};
       //todo: could add all conversions here
       case(_){assert(false);/*unreachable*/[];};
     };
-  };
-
-  /// Convert a `Candy` to Bytes(`[Nat8]`)
-  ///
-  /// Example:
-  /// ```motoko include=import
-  /// let value: Candy = #Principal(Principal.fromText("abc"));
-  /// let value_as_bytes = Conversion.candyToBytes(value);
-  /// ```
-  public func candyToBytes(val : Candy) : [Nat8]{
-    switch(val){
-      case(#Int(val)){intToBytes(val)};
-      case(#Int8(val)){candyToBytes(#Int(candyToInt(#Int8(val))))};
-      case(#Int16(val)){candyToBytes(#Int(candyToInt(#Int16(val))))};
-      case(#Int32(val)){candyToBytes(#Int(candyToInt(#Int32(val))))};
-      case(#Int64(val)){candyToBytes(#Int(candyToInt(#Int64(val))))};
-      case(#Nat(val)){natToBytes(val)};
-      case(#Nat8(val)){ [val]};
-      case(#Nat16(val)){nat16ToBytes(val)};
-      case(#Nat32(val)){nat32ToBytes(val)};
-      case(#Nat64(val)){nat64ToBytes(val)};
-      case(#Float(val)){Prelude.nyi()};
-      case(#Text(val)){textToBytes(val)};
-      case(#Bool(val)){boolToBytes(val)};
-      case(#Blob(val)){ Blob.toArray(val)};
-      case(#Class(val)){Prelude.nyi()};
-      case(#Principal(val)){principalToBytes(val)};
-      case(#Option(val)){Prelude.nyi()};
-      case(#Array(val)){Prelude.nyi()};
-      case(#Bytes(val)){StableBuffer.toArray(val)};
-      case(#Floats(val)){Prelude.nyi()};
-      case(#Nats(val)){Prelude.nyi()};
-      case(#Ints(val)){Prelude.nyi()};
-      case(#Map(val)){Prelude.nyi()};
-      case(#Set(val)){Prelude.nyi()};
-    }
   };
 
   /// Convert a `CandyShared` to Bytes(`[Nat8]`)
@@ -1202,25 +1215,6 @@ module {
       case(#Bytes(val)){toBuffer(val)};
       case(_){
           toBuffer<Nat8>(candySharedToBytes(val));//may throw for uncovertable types
-      };
-    };
-  };
-
-
-  /// Convert a `Candy` to `Buffer<Nat8>`
-  ///
-  /// Example:
-  /// ```motoko include=import
-  /// let value: Candy = #Principal(Principal.fromText("abc"));
-  /// let value_as_buffer = Conversion.candyToBytesBuffer(value);
-  /// ```
-  ///
-  /// Note: Throws if the underlying value isn't convertible.
-  public func candyToBytesBuffer(val : Candy) : Buffer.Buffer<Nat8>{
-    switch (val){
-      case(#Bytes(val)){Buffer.fromArray(StableBuffer.toArray(val))};
-      case(_){
-          toBuffer<Nat8>(candyToBytes(val));//may throw for uncovertable types
       };
     };
   };
@@ -1282,9 +1276,6 @@ module {
     };
   };
 
-  
-
-
   //////////////////////////////////////////////////////////////////////
   // The following functions easily creates a buffer from an arry of any type
   //////////////////////////////////////////////////////////////////////
@@ -1318,7 +1309,6 @@ module {
   ///  let bytes = Conversion.nat64ToBytes(value);
   /// ```
   public func nat64ToBytes(x : Nat64) : [Nat8] {
-    
     [ Nat8.fromNat(Nat64.toNat((x >> 56) & (255))),
     Nat8.fromNat(Nat64.toNat((x >> 48) & (255))),
     Nat8.fromNat(Nat64.toNat((x >> 40) & (255))),
@@ -1337,7 +1327,6 @@ module {
   ///  let bytes = Conversion.nat32ToBytes(value);
   /// ```
   public func nat32ToBytes(x : Nat32) : [Nat8] {
-    
     [ Nat8.fromNat(Nat32.toNat((x >> 24) & (255))),
     Nat8.fromNat(Nat32.toNat((x >> 16) & (255))),
     Nat8.fromNat(Nat32.toNat((x >> 8) & (255))),
@@ -1352,7 +1341,6 @@ module {
   ///  let bytes = Conversion.nat16ToBytes(value);
   /// ```
   public func nat16ToBytes(x : Nat16) : [Nat8] {
-    
     [ Nat8.fromNat(Nat16.toNat((x >> 8) & (255))),
     Nat8.fromNat(Nat16.toNat((x & 255))) ];
   };
@@ -1365,7 +1353,6 @@ module {
   ///  let value = Conversion.bytesToNat16(bytes);
   /// ```
   public func bytesToNat16(bytes: [Nat8]) : Nat16{
-    
     (Nat16.fromNat(Nat8.toNat(bytes[0])) << 8) +
     (Nat16.fromNat(Nat8.toNat(bytes[1])));
   };
@@ -1378,7 +1365,6 @@ module {
   ///  let value = Conversion.bytesToNat32(bytes);
   /// ```
   public func bytesToNat32(bytes: [Nat8]) : Nat32{
-    
     (Nat32.fromNat(Nat8.toNat(bytes[0])) << 24) +
     (Nat32.fromNat(Nat8.toNat(bytes[1])) << 16) +
     (Nat32.fromNat(Nat8.toNat(bytes[2])) << 8) +
@@ -1412,7 +1398,6 @@ module {
   ///  let bytes = Conversion.natToBytes(value);
   /// ```
   public func natToBytes(n : Nat) : [Nat8] {
-    
     var a : Nat8 = 0;
     var b : Nat = n;
     var bytes = List.nil<Nat8>();
@@ -1434,7 +1419,6 @@ module {
   ///  let value = Conversion.bytesToNat(bytes);
   /// ```
   public func bytesToNat(bytes : [Nat8]) : Nat {
-    
     var n : Nat = 0;
     var i = 0;
     Array.foldRight<Nat8, ()>(bytes, (), func (byte, _) {
@@ -1453,7 +1437,6 @@ module {
   ///  let buf = Conversion.textToByteBuffer(t);
   /// ```
   public func textToByteBuffer(_text : Text) : Buffer.Buffer<Nat8>{
-    
     let result : Buffer.Buffer<Nat8> = Buffer.Buffer<Nat8>((_text.size() * 4) +4);
     for(thisChar in _text.chars()){
       for(thisByte in nat32ToBytes(Char.toNat32(thisChar)).vals()){
@@ -1471,7 +1454,6 @@ module {
   ///  let bytes = Conversion.textToBytes(t);
   /// ```
   public func textToBytes(_text : Text) : [Nat8]{
-    
     return Buffer.toArray(textToByteBuffer(_text));
   };
 
@@ -1582,7 +1564,6 @@ module {
   /// let bytes_as_text = Conversion.bytesToText(bytes);
   /// ```
   public func bytesToText(_bytes : [Nat8]) : Text{
-    
     var result : Text = "";
     var aChar : [var Nat8] = [var 0, 0, 0, 0];
 
@@ -1606,7 +1587,6 @@ module {
   /// let principal_as_bytes = Conversion.principalToBytes(p);
   /// ```
   public func principalToBytes(_principal: Principal) : [Nat8]{
-    
     return Blob.toArray(Principal.toBlob(_principal));
   };
 
@@ -1618,7 +1598,6 @@ module {
   /// let p = Conversion.bytesToPrincipal(bytes);
   /// ```
   public func bytesToPrincipal(_bytes: [Nat8]) : Principal{
-    
     return Principal.fromBlob(Blob.fromArray(_bytes));
   };
 
@@ -1630,7 +1609,6 @@ module {
   /// let bool_as_bytes = Conversion.boolToBytes(b);
   /// ```
   public func boolToBytes(_bool : Bool) : [Nat8]{
-    
     if(_bool == true){
       return [1:Nat8];
     } else {
@@ -1646,7 +1624,6 @@ module {
   /// let b = Conversion.bytesToBool(bytes); // true
   /// ```
   public func bytesToBool(_bytes : [Nat8]) : Bool{
-    
     if(_bytes[0] == 0){
       return false;
     } else {
@@ -1662,7 +1639,6 @@ module {
   /// let int_as_bytes = Conversion.intToBytes(b); // [0, 2, 10]
   /// ```
   public func intToBytes(n : Int) : [Nat8]{
-    
     var a : Nat8 = 0;
     var c : Nat8 = if(n < 0){1}else{0};
     var b : Nat = Int.abs(n);
@@ -1688,7 +1664,6 @@ module {
   /// let b = Conversion.bytesToBool(bytes); // 266
   /// ```
   public func bytesToInt(_bytes : [Nat8]) : Int{
-    
     var n : Int = 0;
     var i = 0;
     let natBytes = Array.tabulate<Nat8>(_bytes.size() - 2, func(idx){_bytes[idx+1]});
@@ -1742,7 +1717,6 @@ module {
   /// let unwrapped_val = Conversion.unwrapOptionCandy(val);
   /// ```
   public func unwrapOptionCandyShared(val : CandyShared): CandyShared{
-    
     switch(val){
       case(#Option(val)){
           switch(val){
@@ -1757,5 +1731,4 @@ module {
       case(_){val};
     };
   };
-
 }

--- a/src/conversion.mo
+++ b/src/conversion.mo
@@ -1352,6 +1352,27 @@ module {
   // From there you can easily get to blobs if necessary with the Blob package
   //////////////////////////////////////////////////////////////////////
 
+  /// Convert a `Nat` to Bytes(`[Nat8]`)
+  ///
+  /// Example:
+  /// ```motoko include=import
+  ///  let value: Nat = 150;
+  ///  let bytes = Conversion.natToBytes(value);
+  /// ```
+  public func natToBytes(n : Nat) : [Nat8] {
+    var a : Nat8 = 0;
+    var b : Nat = n;
+    var bytes = List.nil<Nat8>();
+    var test = true;
+    while test {
+      a := Nat8.fromNat(b % 256);
+      b := b / 256;
+      bytes := List.push<Nat8>(a, bytes);
+      test := b > 0;
+    };
+    List.toArray<Nat8>(bytes);
+  };
+
   /// Convert a `Nat64` to Bytes(`[Nat8]`)
   ///
   /// Example:
@@ -1439,27 +1460,6 @@ module {
     (Nat64.fromNat(Nat8.toNat(bytes[5])) << 16) +
     (Nat64.fromNat(Nat8.toNat(bytes[6])) << 8) +
     (Nat64.fromNat(Nat8.toNat(bytes[7])));
-  };
-
-  /// Convert a `Nat` to Bytes(`[Nat8]`)
-  ///
-  /// Example:
-  /// ```motoko include=import
-  ///  let value: Nat = 150;
-  ///  let bytes = Conversion.natToBytes(value);
-  /// ```
-  public func natToBytes(n : Nat) : [Nat8] {
-    var a : Nat8 = 0;
-    var b : Nat = n;
-    var bytes = List.nil<Nat8>();
-    var test = true;
-    while test {
-      a := Nat8.fromNat(b % 256);
-      b := b / 256;
-      bytes := List.push<Nat8>(a, bytes);
-      test := b > 0;
-    };
-    List.toArray<Nat8>(bytes);
   };
 
   /// Convert Bytes(`[Nat8]`) to `Nat`
@@ -1564,7 +1564,6 @@ module {
   /// ```
   public func propertyToText(a: Types.Property):Text{candyToText(a.value)};
 
-
   /// Convert `PropertyShared` to a `Text`
   ///
   /// Example:
@@ -1576,7 +1575,7 @@ module {
   /// };
   /// let prop_as_text = Conversion.propertyToText(t);
   /// ```
-  public func propertySharedToText(a: Types.Property):Text{candyToText(a.value)};
+  public func propertySharedToText(a: Types.PropertyShared):Text{candySharedToText(a.value)};
 
   /// Convert `Candy` to `Properties`
   ///


### PR DESCRIPTION
The following changes have been made in this PR:

- [x] Tidy up README
- [x] Implementing any missing conversion methods
    - [x] `candyToFloatsBuffer`
    - [x] `candyToNatsBuffer`
    - [x]  `stableBufferToBuffer`
- [x] Bug fixes
    - [x]  Fix `propertySharedToText` to take `PropertyShared` as argument instead of `Property`