### PR TITLE
Float.format -> Float.toText

### DIFF
--- a/src/json.mo
+++ b/src/json.mo
@@ -130,7 +130,7 @@ module {
             case(#Bool(val)){ "\"" # Bool.toText(val) # "\"";};	
             
             //float	
-            case(#Float(val)){ Float.format(#exact, val) ;};
+            case(#Float(val)){ Float.toText(val) ;};
             case(#Empty){ "null";};
             case(#Int(val)){Int.toText(val);};
             case(#Int64(val)){Int64.toText(val);};


### PR DESCRIPTION
Float.format() from the Motoko base library seems to be slight causing precision errors whereas Float.toText() does not